### PR TITLE
Removed ABIEncoderV2 (deprecated)

### DIFF
--- a/src/interfaces/IPump.sol
+++ b/src/interfaces/IPump.sol
@@ -1,4 +1,6 @@
-// SPDX-License-Identifier: MIT
+/**
+ * SPDX-License-Identifier: MIT
+ **/
 
 pragma solidity =0.8.17;
 pragma abicoder v2;
@@ -6,10 +8,12 @@ pragma abicoder v2;
 /**
  * @title IPump defines the interface for a Pump.
  *
- * @dev Pumps are on-chain oracles that are updated upon each interaction with a {IWell}.
+ * @dev
+ * Pumps are on-chain oracles that are updated upon each interaction with a {IWell}.
  * When reading a Pump, always verify the Pump's functionality.
  */
 interface IPump {
+
     /**
      * @notice Attaches the Pump to a Well.
      * @param n The number of tokens in the Well
@@ -34,5 +38,5 @@ interface IPump {
      * @param readData The data to be read by the Pump
      * @return data The data read from the Pump
      */
-    function read(address well, bytes calldata readData) external view returns (bytes memory data);
-}
+    function read(address well, bytes calldata readData) view external returns (bytes memory data);
+} 

--- a/src/interfaces/IWellFunction.sol
+++ b/src/interfaces/IWellFunction.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.17;
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 
 /**
  * @title IWellFunction

--- a/src/interfaces/pumps/ICumulativePump.sol
+++ b/src/interfaces/pumps/ICumulativePump.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity =0.8.17;
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 
 /**
  * @title Cumulative Pumps provide an Oracle for time weighted average reserves through the use of a cumulative reserve.

--- a/src/interfaces/pumps/IInstantaneousPump.sol
+++ b/src/interfaces/pumps/IInstantaneousPump.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity =0.8.17;
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 
 /**
  * @title Instantaneous Pumps provide an Oracle for instantaneous reserves.


### PR DESCRIPTION
# Removed ABIEncoderV2 (deprecated)

Switched ABIEncoderV2 to abicoderv2 given the former is deprecated due to 0.8.0 breaking changes.

Link: https://docs.soliditylang.org/en/v0.8.18/080-breaking-changes.html#silent-changes-of-the-semantics

## Visual

<img width="641" alt="Screenshot 2023-02-16 at 3 35 23 PM" src="https://user-images.githubusercontent.com/33232379/219480956-e69d3bbf-acd9-4a70-9906-4d901674bfcd.png">
