### PR TITLE
Combine `fromUInt` and `log_2` methods into one gas-optimized function

### DIFF
--- a/src/libraries/ABDKMathQuad.sol
+++ b/src/libraries/ABDKMathQuad.sol
@@ -104,7 +104,88 @@ library ABDKMathQuad {
      * @param x unsigned 256-bit integer number
      * @return quadruple precision number
      */
-    function fromUInt(uint x) internal pure returns (bytes16) {
+    function fromUIntToLog2(uint x) internal pure returns (bytes16) {
+        unchecked {
+            if (x == 0) {
+                return bytes16(0);
+            } else {
+                uint result = x;
+
+                uint msb = mostSignificantBit(result);
+                if (msb < 112) result <<= 112 - msb;
+                else if (msb > 112) result >>= msb - 112;
+
+                result = result & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF | 16_383 + msb << 112;
+                // return bytes16(uint128(result));
+
+                // log_2 stuff
+                // x here should be replaced with result 
+                if (uint128(result) > 0x80000000000000000000000000000000) {
+                    return NaN;
+                } else if (bytes16(uint128(result)) == 0x3FFF0000000000000000000000000000) {
+                    return POSITIVE_ZERO;
+                } else {
+                    uint xExponent = uint128(result) >> 112 & 0x7FFF;
+                    if (xExponent == 0x7FFF) {
+                        return bytes16(uint128(result));
+                    } else {
+                        uint xSignifier = result & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+                        if (xExponent == 0) xExponent = 1;
+                        else xSignifier |= 0x10000000000000000000000000000;
+
+                        if (xSignifier == 0) return NEGATIVE_INFINITY;
+
+                        bool resultNegative;
+                        uint resultExponent = 16_495;
+                        uint resultSignifier;
+
+                        if (xExponent >= 0x3FFF) {
+                            resultNegative = false;
+                            resultSignifier = xExponent - 0x3FFF;
+                            xSignifier <<= 15;
+                        } else {
+                            resultNegative = true;
+                            if (xSignifier >= 0x10000000000000000000000000000) {
+                                resultSignifier = 0x3FFE - xExponent;
+                                xSignifier <<= 15;
+                            } else {
+                                msb = mostSignificantBit(xSignifier);
+                                resultSignifier = 16_493 - msb;
+                                xSignifier <<= 127 - msb;
+                            }
+                        }
+
+                        if (xSignifier == 0x80000000000000000000000000000000) {
+                            if (resultNegative) resultSignifier += 1;
+                            uint shift = 112 - mostSignificantBit(resultSignifier);
+                            resultSignifier <<= shift;
+                            resultExponent -= shift;
+                        } else {
+                            uint bb = resultNegative ? 1 : 0;
+                            while (resultSignifier < 0x10000000000000000000000000000) {
+                                resultSignifier <<= 1;
+                                resultExponent -= 1;
+
+                                xSignifier *= xSignifier;
+                                uint b = xSignifier >> 255;
+                                resultSignifier += b ^ bb;
+                                xSignifier >>= 127 + b;
+                            }
+                        }
+
+                        return bytes16(
+                            uint128(
+                                (resultNegative ? 0x80000000000000000000000000000000 : 0) | resultExponent << 112
+                                    | resultSignifier & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                            )
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    function fromUInt(uint x) internal pure returns (bytes16){
         unchecked {
             if (x == 0) {
                 return bytes16(0);
@@ -117,7 +198,7 @@ library ABDKMathQuad {
 
                 result = result & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF | 16_383 + msb << 112;
 
-                return bytes16(uint128(result));
+                return bytes16(uint128(result));             
             }
         }
     }
@@ -1486,6 +1567,453 @@ library ABDKMathQuad {
                 }
 
                 return bytes16(uint128(resultExponent << 112 | resultSignifier));
+            }
+        }
+    }
+
+    function pow_2ToUInt(bytes16 x) internal pure returns (uint) {
+        unchecked {
+            bool xNegative = uint128(x) > 0x80000000000000000000000000000000;
+            uint xExponent = uint128(x) >> 112 & 0x7FFF;
+            uint xSignifier = uint128(x) & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+
+            if (xExponent == 0x7FFF && xSignifier != 0) {
+                return uint128(NaN);
+            } else if (xExponent > 16_397) {
+                return xNegative ? uint128(POSITIVE_ZERO) : uint128(POSITIVE_INFINITY);
+            } else if (xExponent < 16_255) {
+                return 0x3FFF0000000000000000000000000000;
+            } else {
+                if (xExponent == 0) xExponent = 1;
+                else xSignifier |= 0x10000000000000000000000000000;
+
+                if (xExponent > 16_367) {
+                    xSignifier <<= xExponent - 16_367;
+                } else if (xExponent < 16_367) {
+                    xSignifier >>= 16_367 - xExponent;
+                }
+
+                if (xNegative && xSignifier > 0x406E00000000000000000000000000000000) {
+                    return uint128(POSITIVE_ZERO);
+                }
+
+                if (!xNegative && xSignifier > 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) {
+                    return uint128(POSITIVE_INFINITY);
+                }
+
+                uint resultExponent = xSignifier >> 128;
+                xSignifier &= 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+                if (xNegative && xSignifier != 0) {
+                    xSignifier = ~xSignifier;
+                    resultExponent += 1;
+                }
+
+                uint resultSignifier = 0x80000000000000000000000000000000;
+                if (xSignifier & 0x80000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x16A09E667F3BCC908B2FB1366EA957D3E >> 128;
+                }
+                if (xSignifier & 0x40000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1306FE0A31B7152DE8D5A46305C85EDEC >> 128;
+                }
+                if (xSignifier & 0x20000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1172B83C7D517ADCDF7C8C50EB14A791F >> 128;
+                }
+                if (xSignifier & 0x10000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10B5586CF9890F6298B92B71842A98363 >> 128;
+                }
+                if (xSignifier & 0x8000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1059B0D31585743AE7C548EB68CA417FD >> 128;
+                }
+                if (xSignifier & 0x4000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x102C9A3E778060EE6F7CACA4F7A29BDE8 >> 128;
+                }
+                if (xSignifier & 0x2000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10163DA9FB33356D84A66AE336DCDFA3F >> 128;
+                }
+                if (xSignifier & 0x1000000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100B1AFA5ABCBED6129AB13EC11DC9543 >> 128;
+                }
+                if (xSignifier & 0x800000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10058C86DA1C09EA1FF19D294CF2F679B >> 128;
+                }
+                if (xSignifier & 0x400000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1002C605E2E8CEC506D21BFC89A23A00F >> 128;
+                }
+                if (xSignifier & 0x200000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100162F3904051FA128BCA9C55C31E5DF >> 128;
+                }
+                if (xSignifier & 0x100000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000B175EFFDC76BA38E31671CA939725 >> 128;
+                }
+                if (xSignifier & 0x80000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100058BA01FB9F96D6CACD4B180917C3D >> 128;
+                }
+                if (xSignifier & 0x40000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10002C5CC37DA9491D0985C348C68E7B3 >> 128;
+                }
+                if (xSignifier & 0x20000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000162E525EE054754457D5995292026 >> 128;
+                }
+                if (xSignifier & 0x10000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000B17255775C040618BF4A4ADE83FC >> 128;
+                }
+                if (xSignifier & 0x8000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000058B91B5BC9AE2EED81E9B7D4CFAB >> 128;
+                }
+                if (xSignifier & 0x4000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100002C5C89D5EC6CA4D7C8ACC017B7C9 >> 128;
+                }
+                if (xSignifier & 0x2000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000162E43F4F831060E02D839A9D16D >> 128;
+                }
+                if (xSignifier & 0x1000000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000B1721BCFC99D9F890EA06911763 >> 128;
+                }
+                if (xSignifier & 0x800000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000058B90CF1E6D97F9CA14DBCC1628 >> 128;
+                }
+                if (xSignifier & 0x400000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000002C5C863B73F016468F6BAC5CA2B >> 128;
+                }
+                if (xSignifier & 0x200000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000162E430E5A18F6119E3C02282A5 >> 128;
+                }
+                if (xSignifier & 0x100000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000B1721835514B86E6D96EFD1BFE >> 128;
+                }
+                if (xSignifier & 0x80000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000058B90C0B48C6BE5DF846C5B2EF >> 128;
+                }
+                if (xSignifier & 0x40000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000002C5C8601CC6B9E94213C72737A >> 128;
+                }
+                if (xSignifier & 0x20000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000162E42FFF037DF38AA2B219F06 >> 128;
+                }
+                if (xSignifier & 0x10000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000B17217FBA9C739AA5819F44F9 >> 128;
+                }
+                if (xSignifier & 0x8000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000058B90BFCDEE5ACD3C1CEDC823 >> 128;
+                }
+                if (xSignifier & 0x4000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000002C5C85FE31F35A6A30DA1BE50 >> 128;
+                }
+                if (xSignifier & 0x2000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000162E42FF0999CE3541B9FFFCF >> 128;
+                }
+                if (xSignifier & 0x1000000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000B17217F80F4EF5AADDA45554 >> 128;
+                }
+                if (xSignifier & 0x800000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000058B90BFBF8479BD5A81B51AD >> 128;
+                }
+                if (xSignifier & 0x400000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000002C5C85FDF84BD62AE30A74CC >> 128;
+                }
+                if (xSignifier & 0x200000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000162E42FEFB2FED257559BDAA >> 128;
+                }
+                if (xSignifier & 0x100000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000B17217F7D5A7716BBA4A9AE >> 128;
+                }
+                if (xSignifier & 0x80000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000058B90BFBE9DDBAC5E109CCE >> 128;
+                }
+                if (xSignifier & 0x40000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000002C5C85FDF4B15DE6F17EB0D >> 128;
+                }
+                if (xSignifier & 0x20000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000162E42FEFA494F1478FDE05 >> 128;
+                }
+                if (xSignifier & 0x10000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000B17217F7D20CF927C8E94C >> 128;
+                }
+                if (xSignifier & 0x8000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000058B90BFBE8F71CB4E4B33D >> 128;
+                }
+                if (xSignifier & 0x4000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000002C5C85FDF477B662B26945 >> 128;
+                }
+                if (xSignifier & 0x2000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000162E42FEFA3AE53369388C >> 128;
+                }
+                if (xSignifier & 0x1000000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000B17217F7D1D351A389D40 >> 128;
+                }
+                if (xSignifier & 0x800000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000058B90BFBE8E8B2D3D4EDE >> 128;
+                }
+                if (xSignifier & 0x400000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000002C5C85FDF4741BEA6E77E >> 128;
+                }
+                if (xSignifier & 0x200000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000162E42FEFA39FE95583C2 >> 128;
+                }
+                if (xSignifier & 0x100000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000B17217F7D1CFB72B45E1 >> 128;
+                }
+                if (xSignifier & 0x80000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000058B90BFBE8E7CC35C3F0 >> 128;
+                }
+                if (xSignifier & 0x40000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000002C5C85FDF473E242EA38 >> 128;
+                }
+                if (xSignifier & 0x20000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000162E42FEFA39F02B772C >> 128;
+                }
+                if (xSignifier & 0x10000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000B17217F7D1CF7D83C1A >> 128;
+                }
+                if (xSignifier & 0x8000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000058B90BFBE8E7BDCBE2E >> 128;
+                }
+                if (xSignifier & 0x4000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000002C5C85FDF473DEA871F >> 128;
+                }
+                if (xSignifier & 0x2000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000162E42FEFA39EF44D91 >> 128;
+                }
+                if (xSignifier & 0x1000000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000B17217F7D1CF79E949 >> 128;
+                }
+                if (xSignifier & 0x800000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000058B90BFBE8E7BCE544 >> 128;
+                }
+                if (xSignifier & 0x400000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000002C5C85FDF473DE6ECA >> 128;
+                }
+                if (xSignifier & 0x200000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000162E42FEFA39EF366F >> 128;
+                }
+                if (xSignifier & 0x100000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000B17217F7D1CF79AFA >> 128;
+                }
+                if (xSignifier & 0x80000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000058B90BFBE8E7BCD6D >> 128;
+                }
+                if (xSignifier & 0x40000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000002C5C85FDF473DE6B2 >> 128;
+                }
+                if (xSignifier & 0x20000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000162E42FEFA39EF358 >> 128;
+                }
+                if (xSignifier & 0x10000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000B17217F7D1CF79AB >> 128;
+                }
+                if (xSignifier & 0x8000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000058B90BFBE8E7BCD5 >> 128;
+                }
+                if (xSignifier & 0x4000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000002C5C85FDF473DE6A >> 128;
+                }
+                if (xSignifier & 0x2000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000162E42FEFA39EF34 >> 128;
+                }
+                if (xSignifier & 0x1000000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000B17217F7D1CF799 >> 128;
+                }
+                if (xSignifier & 0x800000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000058B90BFBE8E7BCC >> 128;
+                }
+                if (xSignifier & 0x400000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000002C5C85FDF473DE5 >> 128;
+                }
+                if (xSignifier & 0x200000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000162E42FEFA39EF2 >> 128;
+                }
+                if (xSignifier & 0x100000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000B17217F7D1CF78 >> 128;
+                }
+                if (xSignifier & 0x80000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000058B90BFBE8E7BB >> 128;
+                }
+                if (xSignifier & 0x40000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000002C5C85FDF473DD >> 128;
+                }
+                if (xSignifier & 0x20000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000162E42FEFA39EE >> 128;
+                }
+                if (xSignifier & 0x10000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000B17217F7D1CF6 >> 128;
+                }
+                if (xSignifier & 0x8000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000058B90BFBE8E7A >> 128;
+                }
+                if (xSignifier & 0x4000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000002C5C85FDF473C >> 128;
+                }
+                if (xSignifier & 0x2000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000162E42FEFA39D >> 128;
+                }
+                if (xSignifier & 0x1000000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000B17217F7D1CE >> 128;
+                }
+                if (xSignifier & 0x800000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000058B90BFBE8E6 >> 128;
+                }
+                if (xSignifier & 0x400000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000002C5C85FDF472 >> 128;
+                }
+                if (xSignifier & 0x200000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000162E42FEFA38 >> 128;
+                }
+                if (xSignifier & 0x100000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000B17217F7D1B >> 128;
+                }
+                if (xSignifier & 0x80000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000058B90BFBE8D >> 128;
+                }
+                if (xSignifier & 0x40000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000002C5C85FDF46 >> 128;
+                }
+                if (xSignifier & 0x20000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000162E42FEFA2 >> 128;
+                }
+                if (xSignifier & 0x10000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000B17217F7D0 >> 128;
+                }
+                if (xSignifier & 0x8000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000058B90BFBE7 >> 128;
+                }
+                if (xSignifier & 0x4000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000002C5C85FDF3 >> 128;
+                }
+                if (xSignifier & 0x2000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000162E42FEF9 >> 128;
+                }
+                if (xSignifier & 0x1000000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000B17217F7C >> 128;
+                }
+                if (xSignifier & 0x800000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000058B90BFBD >> 128;
+                }
+                if (xSignifier & 0x400000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000002C5C85FDE >> 128;
+                }
+                if (xSignifier & 0x200000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000162E42FEE >> 128;
+                }
+                if (xSignifier & 0x100000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000B17217F6 >> 128;
+                }
+                if (xSignifier & 0x80000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000058B90BFA >> 128;
+                }
+                if (xSignifier & 0x40000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000002C5C85FC >> 128;
+                }
+                if (xSignifier & 0x20000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000162E42FD >> 128;
+                }
+                if (xSignifier & 0x10000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000B17217E >> 128;
+                }
+                if (xSignifier & 0x8000000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000058B90BE >> 128;
+                }
+                if (xSignifier & 0x4000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000002C5C85E >> 128;
+                }
+                if (xSignifier & 0x2000000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000162E42E >> 128;
+                }
+                if (xSignifier & 0x1000000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000B17216 >> 128;
+                }
+                if (xSignifier & 0x800000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000058B90A >> 128;
+                }
+                if (xSignifier & 0x400000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000002C5C84 >> 128;
+                }
+                if (xSignifier & 0x200000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000162E41 >> 128;
+                }
+                if (xSignifier & 0x100000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000000B1720 >> 128;
+                }
+                if (xSignifier & 0x80000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000058B8F >> 128;
+                }
+                if (xSignifier & 0x40000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000002C5C7 >> 128;
+                }
+                if (xSignifier & 0x20000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000000162E3 >> 128;
+                }
+                if (xSignifier & 0x10000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000000B171 >> 128;
+                }
+                if (xSignifier & 0x8000 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000000058B8 >> 128;
+                }
+                if (xSignifier & 0x4000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000002C5B >> 128;
+                }
+                if (xSignifier & 0x2000 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000000162D >> 128;
+                }
+                if (xSignifier & 0x1000 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000000B16 >> 128;
+                }
+                if (xSignifier & 0x800 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000000058A >> 128;
+                }
+                if (xSignifier & 0x400 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000000002C4 >> 128;
+                }
+                if (xSignifier & 0x200 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000000161 >> 128;
+                }
+                if (xSignifier & 0x100 > 0) {
+                    resultSignifier = resultSignifier * 0x1000000000000000000000000000000B0 >> 128;
+                }
+                if (xSignifier & 0x80 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000000057 >> 128;
+                }
+                if (xSignifier & 0x40 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000000002B >> 128;
+                }
+                if (xSignifier & 0x20 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000000015 >> 128;
+                }
+                if (xSignifier & 0x10 > 0) {
+                    resultSignifier = resultSignifier * 0x10000000000000000000000000000000A >> 128;
+                }
+                if (xSignifier & 0x8 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000000004 >> 128;
+                }
+                if (xSignifier & 0x4 > 0) {
+                    resultSignifier = resultSignifier * 0x100000000000000000000000000000001 >> 128;
+                }
+
+                if (!xNegative) {
+                    resultSignifier = resultSignifier >> 15 & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+                    resultExponent += 0x3FFF;
+                } else if (resultExponent <= 0x3FFE) {
+                    resultSignifier = resultSignifier >> 15 & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+                    resultExponent = 0x3FFF - resultExponent;
+                } else {
+                    resultSignifier = resultSignifier >> resultExponent - 16_367;
+                    resultExponent = 0;
+                }
+
+                uint128 y = uint128(resultExponent << 112 | resultSignifier);
+            
+                uint exponent = uint128(y) >> 112 & 0x7FFF;
+
+                if (exponent < 16_383) return 0; // Underflow
+
+                require(uint128(y) < 0x80000000000000000000000000000000); // Negative
+
+                require(exponent <= 16_638); // Overflow
+                uint result = uint(uint128(y)) & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFF | 0x10000000000000000000000000000;
+
+                if (exponent < 16_495) result >>= 16_495 - exponent;
+                else if (exponent > 16_495) result <<= exponent - 16_495;
+
+                return result;
             }
         }
     }

--- a/src/libraries/LibWellConstructor.sol
+++ b/src/libraries/LibWellConstructor.sol
@@ -83,7 +83,7 @@ library LibWellConstructor {
     /**
      * @notice Encode a Call struct representing an arbitrary call to `target` with additional data `data`.
      */
-    function encodeCall(address target, bytes memory data) public view returns (Call memory) {
+    function encodeCall(address target, bytes memory data) public pure returns (Call memory) {
         return Call(target, data);
     }
 }

--- a/src/pumps/GeoEmaAndCumSmaPump.sol
+++ b/src/pumps/GeoEmaAndCumSmaPump.sol
@@ -61,6 +61,7 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
     function attach(uint _n, bytes calldata pumpData) external {}
 
     function update(uint[] calldata reserves, bytes calldata) external {
+        uint length = reserves.length;
         Reserves memory b;
 
         // All reserves are stored starting at the msg.sender address slot in storage.
@@ -77,15 +78,16 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
 
         // Read: Cumulative & EMA Reserves
         // Start at the slot after `b.lastReserves`
-        uint numSlots = getSlotsOffset(reserves.length);
+        uint numSlots = getSlotsOffset(length);
         assembly {
             slot := add(slot, numSlots)
         }
-        b.emaReserves = slot.readBytes16(reserves.length);
+        b.emaReserves = slot.readBytes16(length);
         assembly {
             slot := add(slot, numSlots)
         }
-        b.cumulativeReserves = slot.readBytes16(reserves.length);
+        b.cumulativeReserves = slot.readBytes16(length);
+
 
         uint deltaTimestamp = getDeltaTimestamp(b.lastTimestamp);
         bytes16 aN = A.powu(deltaTimestamp);
@@ -94,8 +96,8 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
         // TODO: Always require > 1 ???? Round up ????? `Look into timestamp manipulation
         bytes16 blocksPassed = (deltaTimestamp / BLOCK_TIME).fromUInt();
 
-        for (uint i = 0; i < reserves.length; i++) {
-            b.lastReserves[i] = _capReserve(b.lastReserves[i], reserves[i].fromUInt().log_2(), blocksPassed);
+        for (uint i; i < length; i++) {
+            b.lastReserves[i] = _capReserve(b.lastReserves[i], reserves[i].fromUIntToLog2(), blocksPassed);
             b.emaReserves[i] = b.lastReserves[i].mul((ABDKMathQuad.ONE.sub(aN))).add(b.emaReserves[i].mul(aN));
             b.cumulativeReserves[i] = b.cumulativeReserves[i].add(b.lastReserves[i].mul(deltaTimestampBytes));
         }
@@ -123,11 +125,13 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
      * reserves data.
      */
     function _init(bytes32 slot, uint40 lastTimestamp, uint[] memory reserves) internal {
+        uint length = reserves.length;
+
         bytes16[] memory byteReserves = new bytes16[](reserves.length);
 
         // Skip {_capReserve} since we have no prior reference
-        for (uint i = 0; i < reserves.length; i++) {
-            byteReserves[i] = reserves[i].fromUInt().log_2();
+        for (uint i = 0; i < length; i++) {
+            byteReserves[i] = reserves[i].fromUIntToLog2();
         }
 
         // Write: Last Timestamp & Last Reserves
@@ -149,7 +153,7 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
         (,, bytes16[] memory bytesReserves) = slot.readLastReserves();
         reserves = new uint[](bytesReserves.length);
         for (uint i = 0; i < reserves.length; i++) {
-            reserves[i] = bytesReserves[i].pow_2().toUInt();
+            reserves[i] = bytesReserves[i].pow_2ToUInt();
         }
     }
 
@@ -197,7 +201,7 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
         bytes16[] memory byteReserves = slot.readBytes16(n);
         reserves = new uint[](n);
         for (uint i = 0; i < reserves.length; i++) {
-            reserves[i] = byteReserves[i].pow_2().toUInt();
+            reserves[i] = byteReserves[i].pow_2ToUInt();
         }
     }
 
@@ -214,7 +218,7 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
         reserves = new uint[](n);
         for (uint i = 0; i < reserves.length; i++) {
             reserves[i] =
-                lastReserves[i].mul((ABDKMathQuad.ONE.sub(aN))).add(lastEmaReserves[i].mul(aN)).pow_2().toUInt();
+                lastReserves[i].mul((ABDKMathQuad.ONE.sub(aN))).add(lastEmaReserves[i].mul(aN)).pow_2ToUInt();
         }
     }
 
@@ -265,7 +269,7 @@ contract GeoEmaAndCumSmaPump is IPump, IInstantaneousPump, ICumulativePump {
         for (uint i = 0; i < cumulativeReserves.length; i++) {
             // TODO: Unchecked?
             twaReserves[i] =
-                (byteCumulativeReserves[i].sub(byteStartCumulativeReserves[i])).div(deltaTimestamp).pow_2().toUInt();
+                (byteCumulativeReserves[i].sub(byteStartCumulativeReserves[i])).div(deltaTimestamp).pow_2ToUInt();
         }
     }
 

--- a/test/libraries/TestABDK.t.sol
+++ b/test/libraries/TestABDK.t.sol
@@ -56,4 +56,10 @@ contract ABDKTest is TestHelper {
     function powuFraction(uint a, uint b, uint c) public pure returns (bytes16) {
         return a.fromUInt().div(b.fromUInt()).powu(c);
     }
+
+    function testFromUIntToLog2() public {
+        // test the fromUintToLog2 function
+        assertEq(ABDKMathQuad.fromUIntToLog2(1), 0);
+
+    }
 }

--- a/test/libraries/TestABDK.t.sol
+++ b/test/libraries/TestABDK.t.sol
@@ -59,7 +59,19 @@ contract ABDKTest is TestHelper {
 
     function testFromUIntToLog2() public {
         // test the fromUintToLog2 function
-        assertEq(ABDKMathQuad.fromUIntToLog2(1), 0);
+
+        bytes16 result;
+
+        result = ABDKMathQuad.fromUIntToLog2(0);
+        assertEq(result, bytes16(0), "fromUIntToLog2(0) should return 0");
+
+        result = ABDKMathQuad.fromUIntToLog2(1);
+        assertEq(result, bytes16(0x3FFE0000000000000000000000000000), "fromUIntToLog2(1) should return 0x3FFE0000000000000000000000000000");
+
+        result = ABDKMathQuad.fromUIntToLog2(2);
+        assertEq(result, bytes16(0x3FFF0000000000000000000000000000), "fromUIntToLog2(2) should return 0x3FFF0000000000000000000000000000");
+
+        // assertEq(ABDKMathQuad.fromUIntToLog2(1), 0);
 
     }
 }


### PR DESCRIPTION
noticed that we often convert uint ->  quadruple precision number -> log, or pow -> uint 

combined the two functions to save gas 