### PR TITLE
HAL-09: add custom errors to Well.sol

### DIFF
--- a/src/Aquifer.sol
+++ b/src/Aquifer.sol
@@ -55,11 +55,11 @@ contract Aquifer is IAquifer, ReentrancyGuard {
             (bool success, bytes memory returnData) = well.call(initFunctionCall);
             if (!success) {
                 // Next 5 lines are based on https://ethereum.stackexchange.com/a/83577
-                if (returnData.length < 68) revert("Aquifer: well init");
+                if (returnData.length < 68) revert InitFailed("");
                 assembly {
                     returnData := add(returnData, 0x04)
                 }
-                revert(string.concat("Aquifer: Well Init (", abi.decode(returnData, (string)), ")"));
+                revert InitFailed(abi.decode(returnData, (string)));
             }
         }
 

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -212,7 +212,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
         // slippage from imprecision goes to the Well or to the User.
         amountOut = reserveJBefore - reserves[j];
 
-        if(!amountOut >= minAmountOut) revert SlippageOut(amountOut, minAmountOut);
+        if(!(amountOut >= minAmountOut)) revert SlippageOut(amountOut, minAmountOut);
         toToken.safeTransfer(recipient, amountOut);
         emit Swap(fromToken, toToken, amountIn, amountOut, recipient);
         _setReserves(_tokens, reserves);
@@ -252,7 +252,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
 
         // slippage check needs to move to the actual amount out
         // need to take delta across _executeSwap
-        if(!amountIn <= maxAmountIn) revert SlippageIn(amountIn, maxAmountIn);
+        if(!(amountIn <= maxAmountIn)) revert SlippageIn(amountIn, maxAmountIn);
         _executeSwap(fromToken, toToken, amountIn, amountOut, recipient);
         _setReserves(_tokens, reserves);
     }
@@ -327,7 +327,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
             }
         }
         lpAmountOut = _calcLpTokenSupply(wellFunction(), reserves) - totalSupply();
-        if(!lpAmountOut >= minLpAmountOut) revert SlippageOut(lpAmountOut, minLpAmountOut);
+        if(!(lpAmountOut >= minLpAmountOut)) revert SlippageOut(lpAmountOut, minLpAmountOut);
         _mint(recipient, lpAmountOut);
         _setReserves(_tokens, reserves);
         emit AddLiquidity(tokenAmountsIn, lpAmountOut, recipient);
@@ -390,7 +390,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
         uint j = _getJ(_tokens, tokenOut);
 
         tokenAmountOut = _getRemoveLiquidityOneTokenOut(lpAmountIn, j, reserves);
-        if(!tokenAmountOut >= minTokenAmountOut) revert SlippageOut(tokenAmountOut, minTokenAmountOut);
+        if(!(tokenAmountOut >= minTokenAmountOut)) revert SlippageOut(tokenAmountOut, minTokenAmountOut);
         _burn(msg.sender, lpAmountIn);
         tokenOut.safeTransfer(recipient, tokenAmountOut);
 
@@ -441,7 +441,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
             reserves[i] = reserves[i] - tokenAmountsOut[i];
         }
         lpAmountIn = totalSupply() - _calcLpTokenSupply(wellFunction(), reserves);
-        if(!lpAmountIn <= maxLpAmountIn) revert SlippageIn(lpAmountIn, maxLpAmountIn);
+        if(!(lpAmountIn <= maxLpAmountIn)) revert SlippageIn(lpAmountIn, maxLpAmountIn);
         _burn(msg.sender, lpAmountIn);
 
         _setReserves(_tokens, reserves);
@@ -577,7 +577,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
      */
     function _setReserves(IERC20[] memory _tokens, uint[] memory reserves) internal {
         for (uint i; i < reserves.length; ++i) {
-            if(!reserves[i] <= _tokens[i].balanceOf(address(this))) revert InvalidReserves();
+            if(!(reserves[i] <= _tokens[i].balanceOf(address(this)))) revert InvalidReserves();
         }
         LibBytes.storeUint128(RESERVES_STORAGE_SLOT, reserves);
     }

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -658,8 +658,8 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
             }
         }
 
-        require(foundI, "Well: Invalid tokens");
-        require(foundJ, "Well: Invalid tokens");
+        if(!foundI) revert InvalidTokens();
+        if(!foundJ) revert InvalidTokens();
     }
 
     /**

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -212,7 +212,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
         // slippage from imprecision goes to the Well or to the User.
         amountOut = reserveJBefore - reserves[j];
 
-        if(!(amountOut >= minAmountOut)) revert SlippageOut(amountOut, minAmountOut);
+        if(amountOut < minAmountOut) revert SlippageOut(amountOut, minAmountOut);
         toToken.safeTransfer(recipient, amountOut);
         emit Swap(fromToken, toToken, amountIn, amountOut, recipient);
         _setReserves(_tokens, reserves);

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -441,7 +441,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
             reserves[i] = reserves[i] - tokenAmountsOut[i];
         }
         lpAmountIn = totalSupply() - _calcLpTokenSupply(wellFunction(), reserves);
-        if(!(lpAmountIn <= maxLpAmountIn)) revert SlippageIn(lpAmountIn, maxLpAmountIn);
+        if(lpAmountIn > maxLpAmountIn) revert SlippageIn(lpAmountIn, maxLpAmountIn);
         _burn(msg.sender, lpAmountIn);
 
         _setReserves(_tokens, reserves);

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -252,7 +252,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
 
         // slippage check needs to move to the actual amount out
         // need to take delta across _executeSwap
-        if(!(amountIn <= maxAmountIn)) revert SlippageIn(amountIn, maxAmountIn);
+        if(amountIn > maxAmountIn) revert SlippageIn(amountIn, maxAmountIn);
         _executeSwap(fromToken, toToken, amountIn, amountOut, recipient);
         _setReserves(_tokens, reserves);
     }

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -327,7 +327,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
             }
         }
         lpAmountOut = _calcLpTokenSupply(wellFunction(), reserves) - totalSupply();
-        if(!(lpAmountOut >= minLpAmountOut)) revert SlippageOut(lpAmountOut, minLpAmountOut);
+        if(lpAmountOut < minLpAmountOut) revert SlippageOut(lpAmountOut, minLpAmountOut);
         _mint(recipient, lpAmountOut);
         _setReserves(_tokens, reserves);
         emit AddLiquidity(tokenAmountsIn, lpAmountOut, recipient);

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -577,7 +577,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
      */
     function _setReserves(IERC20[] memory _tokens, uint[] memory reserves) internal {
         for (uint i; i < reserves.length; ++i) {
-            if(!(reserves[i] <= _tokens[i].balanceOf(address(this)))) revert InvalidReserves();
+            if(reserves[i] > _tokens[i].balanceOf(address(this))) revert InvalidReserves();
         }
         LibBytes.storeUint128(RESERVES_STORAGE_SLOT, reserves);
     }

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -390,7 +390,7 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
         uint j = _getJ(_tokens, tokenOut);
 
         tokenAmountOut = _getRemoveLiquidityOneTokenOut(lpAmountIn, j, reserves);
-        if(!(tokenAmountOut >= minTokenAmountOut)) revert SlippageOut(tokenAmountOut, minTokenAmountOut);
+        if(tokenAmountOut < minTokenAmountOut) revert SlippageOut(tokenAmountOut, minTokenAmountOut);
         _burn(msg.sender, lpAmountIn);
         tokenOut.safeTransfer(recipient, tokenAmountOut);
 

--- a/src/interfaces/IAquifer.sol
+++ b/src/interfaces/IAquifer.sol
@@ -12,6 +12,11 @@ import {IWell, Call} from "src/interfaces/IWell.sol";
  */
 interface IAquifer {
     /**
+     * @notice Thrown when the {init} function call on the Well reverts.
+     */
+    error InitFailed(string reason);
+
+    /**
      * @notice Emitted when a Well is deployed.
      * @param well The address of the new Well
      * @param implementation The Well implementation address

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -23,17 +23,17 @@ interface IWell {
     error SlippageOut(uint amountOut, uint minAmountOut);
     
     /**
-     * @notice Thrown when an operation would deliver more tokens than `maxAmountIn`.
+     * @notice Thrown when an operation would require more tokens than `maxAmountIn`.
      */
     error SlippageIn(uint amountIn, uint maxAmountIn);
         
-     /**
-     * @notice Thrown if given token is nonexistent.
+    /**
+     * @notice Thrown if one or more tokens used in the operation are not supported by the Well.
      */
     error InvalidTokens();
        
     /**
-     * @notice Thrown if reserves don't match the condition provided.
+     * @notice Thrown if this operation would cause an incorrect change in Well reserves.
      */
     error InvalidReserves();
 

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -19,15 +19,11 @@ interface IWell {
   
     /**
      * @notice Thrown when an operation would deliver fewer tokens than `minAmountOut`.
-     * @return amountOut 
-     * @return minAmountOut 
      */
     error SlippageOut(uint amountOut, uint minAmountOut);
     
     /**
      * @notice Thrown when an operation would deliver more tokens than `maxAmountIn`.
-     * @return amountIn 
-     * @return maxAmountIn 
      */
     error SlippageIn(uint amountIn, uint maxAmountIn);
         

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -16,14 +16,18 @@ struct Call {
  * @title IWell is the interface for the Well contract.
  */
 interface IWell {
+
     /// @notice Thrown when an operation would deliver fewer tokens than `minAmountOut`.
     /// @dev Returns only a uint amountOut and a uint minAmountOut.
     error SlippageOut(uint amountOut, uint minAmountOut);
+    
     /// @notice Returns the slippage of swapping `amountIn` of `fromToken` for `toToken`.
     /// @dev Returns only a uint amounntIn and a uint maxAmountIn.
     error SlippageIn(uint amountIn, uint maxAmountIn);
+    
     /// @notice Returns the amount of leaves the tree has.
     error InvalidTokens();
+    
     /// @notice Returns the amount of leaves the tree has.
     error InvalidReserves();
 

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -16,9 +16,15 @@ struct Call {
  * @title IWell is the interface for the Well contract.
  */
 interface IWell {
+    /// @notice Returns the slippage of swapping `amountOut` of `fromToken` for `toToken`.
+    /// @dev Returns only a uint amountOut and a uint minAmountOut.
     error SlippageOut(uint amountOut, uint minAmountOut);
+    /// @notice Returns the slippage of swapping `amountIn` of `fromToken` for `toToken`.
+    /// @dev Returns only a uint amounntIn and a uint maxAmountIn.
     error SlippageIn(uint amountIn, uint maxAmountIn);
+    /// @notice Returns the amount of leaves the tree has.
     error InvalidTokens();
+    /// @notice Returns the amount of leaves the tree has.
     error InvalidReserves();
 
     /**

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -16,6 +16,11 @@ struct Call {
  * @title IWell is the interface for the Well contract.
  */
 interface IWell {
+    error SlippageOut(uint amountOut, uint minAmountOut);
+    error SlippageIn(uint amountIn, uint maxAmountIn);
+    error InvalidTokens();
+    error InvalidReserves();
+
     /**
      * @notice Emitted when a Swap occurs.
      * @param fromToken The token swapped from

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -16,7 +16,7 @@ struct Call {
  * @title IWell is the interface for the Well contract.
  */
 interface IWell {
-    /// @notice Returns the slippage of swapping `amountOut` of `fromToken` for `toToken`.
+    /// @notice Thrown when an operation would deliver fewer tokens than `minAmountOut`.
     /// @dev Returns only a uint amountOut and a uint minAmountOut.
     error SlippageOut(uint amountOut, uint minAmountOut);
     /// @notice Returns the slippage of swapping `amountIn` of `fromToken` for `toToken`.

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -21,14 +21,14 @@ interface IWell {
     /// @dev Returns only a uint amountOut and a uint minAmountOut.
     error SlippageOut(uint amountOut, uint minAmountOut);
     
-    /// @notice Returns the slippage of swapping `amountIn` of `fromToken` for `toToken`.
+    /// @notice Thrown when an operation would deliver more tokens than `maxAmountIn`.
     /// @dev Returns only a uint amounntIn and a uint maxAmountIn.
     error SlippageIn(uint amountIn, uint maxAmountIn);
     
-    /// @notice Returns the amount of leaves the tree has.
+    /// @notice Thrown if given token is nonexistent
     error InvalidTokens();
     
-    /// @notice Returns the amount of leaves the tree has.
+    /// @notice Thrown if reserves don't match the condition provided
     error InvalidReserves();
 
     /**

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -16,19 +16,29 @@ struct Call {
  * @title IWell is the interface for the Well contract.
  */
 interface IWell {
-
-    /// @notice Thrown when an operation would deliver fewer tokens than `minAmountOut`.
-    /// @dev Returns only a uint amountOut and a uint minAmountOut.
+  
+    /**
+     * @notice Thrown when an operation would deliver fewer tokens than `minAmountOut`.
+     * @return amountOut 
+     * @return minAmountOut 
+     */
     error SlippageOut(uint amountOut, uint minAmountOut);
     
-    /// @notice Thrown when an operation would deliver more tokens than `maxAmountIn`.
-    /// @dev Returns only a uint amounntIn and a uint maxAmountIn.
+    /**
+     * @notice Thrown when an operation would deliver more tokens than `maxAmountIn`.
+     * @return amountIn 
+     * @return maxAmountIn 
+     */
     error SlippageIn(uint amountIn, uint maxAmountIn);
-    
-    /// @notice Thrown if given token is nonexistent
+        
+     /**
+     * @notice Thrown if given token is nonexistent.
+     */
     error InvalidTokens();
-    
-    /// @notice Thrown if reserves don't match the condition provided
+       
+    /**
+     * @notice Thrown if reserves don't match the condition provided.
+     */
     error InvalidReserves();
 
     /**

--- a/test/Aquifer.t.sol
+++ b/test/Aquifer.t.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.17;
 import {TestHelper, Well, IERC20, console} from "test/TestHelper.sol";
 import {MockStaticWell} from "mocks/wells/MockStaticWell.sol";
 import {MockPump} from "mocks/pumps/MockPump.sol";
+import {IAquifer} from "src/interfaces/IAquifer.sol";
 import {IWell, Call} from "src/interfaces/IWell.sol";
 import {ConstantProduct} from "src/functions/ConstantProduct.sol";
 import {LibClone} from "src/libraries/LibClone.sol";
@@ -141,7 +142,7 @@ contract AquiferTest is TestHelper {
     function test_bore_fail_message() public {
         initFunctionCall = abi.encodeWithSignature("initMessage()");
 
-        vm.expectRevert("Aquifer: Well Init (Well: fail message)");
+        vm.expectRevert(abi.encodeWithSelector(IAquifer.InitFailed.selector, "Well: fail message"));
         aquifer.boreWell(
             initFailImplementation,
             "",
@@ -153,7 +154,7 @@ contract AquiferTest is TestHelper {
     function test_bore_fail_no_message() public {
         initFunctionCall = abi.encodeWithSignature("initNoMessage()");
 
-        vm.expectRevert("Aquifer: well init");
+        vm.expectRevert(abi.encodeWithSelector(IAquifer.InitFailed.selector, ""));
         aquifer.boreWell(
             initFailImplementation,
             "",

--- a/test/Well.AddLiquidity.t.sol
+++ b/test/Well.AddLiquidity.t.sol
@@ -6,6 +6,9 @@ import {TestHelper, IERC20, Call, Balances} from "test/TestHelper.sol";
 import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
 
 contract WellAddLiquidityTest is TestHelper {
+
+    error SlippageOut(uint amountOut, uint minAmountOut);
+
     event AddLiquidity(uint[] tokenAmountsIn, uint lpAmountOut, address recipient);
     event RemoveLiquidity(uint lpAmountIn, uint[] tokenAmountsOut, address recipient);
 
@@ -101,7 +104,7 @@ contract WellAddLiquidityTest is TestHelper {
         for (uint i = 0; i < tokens.length; i++) {
             amounts[i] = 1000 * 1e18;
         }
-        vm.expectRevert("Well: slippage");
+        // vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, 2001 * 1e27, amounts));
         well.addLiquidity(amounts, 2001 * 1e27, user); // lpAmountOut is 2000*1e27
     }
 

--- a/test/Well.AddLiquidity.t.sol
+++ b/test/Well.AddLiquidity.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.17;
 
 import {TestHelper, IERC20, Call, Balances} from "test/TestHelper.sol";
-import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";=======
+import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
 import {Snapshot, AddLiquidityAction, RemoveLiquidityAction, LiquidityHelper} from "test/LiquidityHelper.sol";
 
 contract WellAddLiquidityTest is LiquidityHelper {

--- a/test/Well.AddLiquidity.t.sol
+++ b/test/Well.AddLiquidity.t.sol
@@ -8,7 +8,7 @@ import {Snapshot, AddLiquidityAction, RemoveLiquidityAction, LiquidityHelper} fr
 
 contract WellAddLiquidityTest is LiquidityHelper {
     error SlippageOut(uint amountOut, uint minAmountOut);
-    
+
     function setUp() public {
         setupWell(2);
     }
@@ -99,8 +99,9 @@ contract WellAddLiquidityTest is LiquidityHelper {
         for (uint i = 0; i < tokens.length; i++) {
             amounts[i] = 1000 * 1e18;
         }
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, 2001 * 1e27, amounts));
-        well.addLiquidity(amounts, 2001 * 1e27, user); // lpAmountOut is 2000*1e27
+        uint lpAmountOut = well.getAddLiquidityOut(amounts);
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, lpAmountOut, lpAmountOut + 1));
+        well.addLiquidity(amounts, lpAmountOut + 1, user); // lpAmountOut is 2000*1e27
     }
 
     /// @dev addLiquidity -> removeLiquidity: zero hysteresis

--- a/test/Well.AddLiquidity.t.sol
+++ b/test/Well.AddLiquidity.t.sol
@@ -104,7 +104,7 @@ contract WellAddLiquidityTest is TestHelper {
         for (uint i = 0; i < tokens.length; i++) {
             amounts[i] = 1000 * 1e18;
         }
-        // vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, 2001 * 1e27, amounts));
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, 2001 * 1e27, amounts));
         well.addLiquidity(amounts, 2001 * 1e27, user); // lpAmountOut is 2000*1e27
     }
 

--- a/test/Well.AddLiquidityFeeOnTransfer.Fee.t.sol
+++ b/test/Well.AddLiquidityFeeOnTransfer.Fee.t.sol
@@ -7,9 +7,8 @@ import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.so
 import {Snapshot, AddLiquidityAction, RemoveLiquidityAction, LiquidityHelper} from "test/LiquidityHelper.sol";
 
 contract WellAddLiquidityFeeOnTransferFeeTest is LiquidityHelper {
-
     error SlippageOut(uint amountOut, uint minAmountOut);
-    
+
     function setUp() public {
         setupWell(deployWellFunction(), deployPumps(2), deployMockTokensFeeOnTransfer(2));
         MockTokenFeeOnTransfer(address(tokens[0])).setFee(1e16);
@@ -74,8 +73,10 @@ contract WellAddLiquidityFeeOnTransferFeeTest is LiquidityHelper {
         for (uint i = 0; i < tokens.length; i++) {
             amounts[i] = 1000 * 1e18;
         }
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, 0, 1));
-        well.addLiquidityFeeOnTransfer(amounts, 2000 * 1e27, user); // lpAmountOut is 1980*1e27
+
+        uint lpAmountOut = 1980 * 1e27;
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, lpAmountOut, lpAmountOut + 1));
+        well.addLiquidityFeeOnTransfer(amounts, lpAmountOut + 1, user); // lpAmountOut is 1980*1e27
     }
 
     /// @dev addLiquidity: adding zero liquidity emits empty event but doesn't change reserves

--- a/test/Well.AddLiquidityFeeOnTransfer.Fee.t.sol
+++ b/test/Well.AddLiquidityFeeOnTransfer.Fee.t.sol
@@ -6,6 +6,9 @@ import {MockTokenFeeOnTransfer, TestHelper, IERC20, Call, Balances} from "test/T
 import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
 
 contract WellAddLiquidityFeeOnTransferFeeTest is TestHelper {
+
+    error SlippageOut(uint amountOut, uint minAmountOut);
+
     event AddLiquidity(uint[] tokenAmountsIn, uint lpAmountOut, address recipient);
 
     function setUp() public {
@@ -73,7 +76,7 @@ contract WellAddLiquidityFeeOnTransferFeeTest is TestHelper {
         for (uint i = 0; i < tokens.length; i++) {
             amounts[i] = 1000 * 1e18;
         }
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, 0, 1));
         well.addLiquidityFeeOnTransfer(amounts, 2000 * 1e27, user); // lpAmountOut is 1980*1e27
     }
 

--- a/test/Well.AddLiquidityFeeOnTransfer.NoFee.t.sol
+++ b/test/Well.AddLiquidityFeeOnTransfer.NoFee.t.sol
@@ -6,6 +6,9 @@ import {TestHelper, IERC20, Call, Balances} from "test/TestHelper.sol";
 import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
 
 contract WellAddLiquidityFeeOnTransferNoFeeTest is TestHelper {
+
+    error SlippageOut(uint amountOut, uint minAmountOut);
+
     event AddLiquidity(uint[] tokenAmountsIn, uint lpAmountOut, address recipient);
     event RemoveLiquidity(uint lpAmountIn, uint[] tokenAmountsOut, address recipient);
 
@@ -67,7 +70,7 @@ contract WellAddLiquidityFeeOnTransferNoFeeTest is TestHelper {
         for (uint i = 0; i < tokens.length; i++) {
             amounts[i] = 1000 * 1e18;
         }
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amounts, 2001 * 1e27));
         well.addLiquidityFeeOnTransfer(amounts, 2001 * 1e27, user); // lpAmountOut is 2000*1e27
     }
 

--- a/test/Well.AddLiquidityFeeOnTransfer.NoFee.t.sol
+++ b/test/Well.AddLiquidityFeeOnTransfer.NoFee.t.sol
@@ -7,9 +7,8 @@ import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.so
 import {Snapshot, AddLiquidityAction, RemoveLiquidityAction, LiquidityHelper} from "test/LiquidityHelper.sol";
 
 contract WellAddLiquidityFeeOnTransferNoFeeTest is LiquidityHelper {
-
     error SlippageOut(uint amountOut, uint minAmountOut);
-    
+
     function setUp() public {
         setupWell(2);
     }
@@ -68,8 +67,10 @@ contract WellAddLiquidityFeeOnTransferNoFeeTest is LiquidityHelper {
         for (uint i = 0; i < tokens.length; i++) {
             amounts[i] = 1000 * 1e18;
         }
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amounts, 2001 * 1e27));
-        well.addLiquidityFeeOnTransfer(amounts, 2001 * 1e27, user); // lpAmountOut is 2000*1e27
+
+        uint lpAmountOut = well.getAddLiquidityOut(amounts);
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, lpAmountOut, lpAmountOut + 1));
+        well.addLiquidityFeeOnTransfer(amounts, lpAmountOut + 1, user); // lpAmountOut is 2000*1e27
     }
 
     /// @dev addLiquidity -> removeLiquidity: zero hysteresis

--- a/test/Well.Bore.t.sol
+++ b/test/Well.Bore.t.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {TestHelper, Well, IERC20, Call, Balances, console} from "test/TestHelper.sol";
+import {TestHelper, Well, IERC20, Call, Balances} from "test/TestHelper.sol";
 import {MockPump} from "mocks/pumps/MockPump.sol";
 import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
 
 contract WellBoreTest is TestHelper {
-    event AddLiquidity(uint[] amounts);
-
     /// @dev Bore a 4-token Well with ConstantProduct2 & several pumps.
     function setUp() public {
         setupWell(4);

--- a/test/Well.FeeOnTransfer.t.sol
+++ b/test/Well.FeeOnTransfer.t.sol
@@ -10,6 +10,9 @@ import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.so
  * (swapFrom, swapTo, addLiquidity) should revert if there actually are fees.
  */
 contract WellFeeOnTransferTest is TestHelper {
+
+    error InvalidReserves();
+
     event AddLiquidity(uint[] tokenAmountsIn, uint lpAmountOut, address recipient);
     event RemoveLiquidity(uint lpAmountIn, uint[] tokenAmountsOut, address recipient);
 
@@ -22,7 +25,7 @@ contract WellFeeOnTransferTest is TestHelper {
         uint minAmountOut = 500 * 1e18;
         uint amountIn = 1000 * 1e18;
 
-        vm.expectRevert("Well: Invalid reserve");
+        vm.expectRevert(InvalidReserves.selector);
         well.swapTo(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 
@@ -30,7 +33,7 @@ contract WellFeeOnTransferTest is TestHelper {
         uint minAmountOut = 500 * 1e18;
         uint amountIn = 1000 * 1e18;
 
-        vm.expectRevert("Well: Invalid reserve");
+        vm.expectRevert(InvalidReserves.selector);
         well.swapFrom(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 
@@ -42,7 +45,7 @@ contract WellFeeOnTransferTest is TestHelper {
         }
         uint lpAmountOut = 2000 * 1e27;
 
-        vm.expectRevert("Well: Invalid reserve");
+        vm.expectRevert(InvalidReserves.selector);
         well.addLiquidity(amounts, lpAmountOut, user);
     }
 }

--- a/test/Well.FeeOnTransfer.t.sol
+++ b/test/Well.FeeOnTransfer.t.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.17;
 
-import {console, TestHelper, IERC20, Call, Balances, MockTokenFeeOnTransfer} from "test/TestHelper.sol";
+import {TestHelper, IERC20, Call, Balances, MockTokenFeeOnTransfer} from "test/TestHelper.sol";
 import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 /**
  * @dev Functions that increase the Well's reserves without accounting for fees
@@ -11,7 +12,6 @@ import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.so
  */
 contract WellFeeOnTransferTest is TestHelper {
 
-    error InvalidReserves();
 
     event AddLiquidity(uint[] tokenAmountsIn, uint lpAmountOut, address recipient);
     event RemoveLiquidity(uint lpAmountIn, uint[] tokenAmountsOut, address recipient);
@@ -25,7 +25,7 @@ contract WellFeeOnTransferTest is TestHelper {
         uint minAmountOut = 500 * 1e18;
         uint amountIn = 1000 * 1e18;
 
-        vm.expectRevert(InvalidReserves.selector);
+        vm.expectRevert(IWell.InvalidReserves.selector);
         well.swapTo(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 
@@ -33,7 +33,7 @@ contract WellFeeOnTransferTest is TestHelper {
         uint minAmountOut = 500 * 1e18;
         uint amountIn = 1000 * 1e18;
 
-        vm.expectRevert(InvalidReserves.selector);
+        vm.expectRevert(IWell.InvalidReserves.selector);
         well.swapFrom(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 
@@ -45,7 +45,7 @@ contract WellFeeOnTransferTest is TestHelper {
         }
         uint lpAmountOut = 2000 * 1e27;
 
-        vm.expectRevert(InvalidReserves.selector);
+        vm.expectRevert(IWell.InvalidReserves.selector);
         well.addLiquidity(amounts, lpAmountOut, user);
     }
 }

--- a/test/Well.RemoveLiquidity.t.sol
+++ b/test/Well.RemoveLiquidity.t.sol
@@ -71,7 +71,7 @@ contract WellRemoveLiquidityTest is TestHelper {
 
     /// @dev removeLiquidity: reverts when user tries to remove too much of an underlying token
     function test_removeLiquidity_amountOutTooHigh() public prank(user) {
-        uint lpAmountIn = 2000 * 1e18;
+        uint lpAmountIn = 2000 * 1e27;
 
         uint[] memory minTokenAmountsOut = new uint[](2);
         minTokenAmountsOut[0] = 1001 * 1e18; // too high

--- a/test/Well.RemoveLiquidity.t.sol
+++ b/test/Well.RemoveLiquidity.t.sol
@@ -8,6 +8,8 @@ contract WellRemoveLiquidityTest is TestHelper {
     bytes constant data = "";
     uint constant addedLiquidity = 1000 * 1e18;
 
+    error SlippageOut(uint amountOut, uint minAmountOut);
+
     event RemoveLiquidity(uint lpAmountIn, uint[] tokenAmountsOut, address recipient);
 
     function setUp() public {
@@ -74,7 +76,7 @@ contract WellRemoveLiquidityTest is TestHelper {
         amountsOut[0] = 1001 * 1e18; // too high
         amountsOut[1] = 1000 * 1e18;
 
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, lpAmountIn, amountsOut[0]));
         well.removeLiquidity(lpAmountIn, amountsOut, user);
     }
 

--- a/test/Well.RemoveLiquidityImbalanced.t.sol
+++ b/test/Well.RemoveLiquidityImbalanced.t.sol
@@ -10,6 +10,8 @@ contract WellRemoveLiquidityImbalancedTest is TestHelper {
 
     uint constant addedLiquidity = 1000 * 1e18;
 
+    error SlippageOut(uint amountOut, uint minAmountOut);
+
     event RemoveLiquidity(uint lpAmountIn, uint[] tokenAmountsOut, address recipient);
 
     function setUp() public {
@@ -58,7 +60,7 @@ contract WellRemoveLiquidityImbalancedTest is TestHelper {
     /// @dev not enough LP to receive `tokenAmountsOut`
     function test_removeLiquidityImbalanced_revertIf_notEnoughLP() public prank(user) {
         uint maxLpAmountIn = 10 * 1e27;
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, tokenAmountsOut[0], 0));
         well.removeLiquidityImbalanced(maxLpAmountIn, tokenAmountsOut, user);
     }
 

--- a/test/Well.RemoveLiquidityImbalanced.t.sol
+++ b/test/Well.RemoveLiquidityImbalanced.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {TestHelper, ConstantProduct2, Balances} from "test/TestHelper.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 contract WellRemoveLiquidityImbalancedTest is TestHelper {
     ConstantProduct2 cp;
@@ -9,8 +10,6 @@ contract WellRemoveLiquidityImbalancedTest is TestHelper {
     uint[] tokenAmountsOut;
 
     uint constant addedLiquidity = 1000 * 1e18;
-
-    error SlippageOut(uint amountOut, uint minAmountOut);
 
     event RemoveLiquidity(uint lpAmountIn, uint[] tokenAmountsOut, address recipient);
 
@@ -60,7 +59,7 @@ contract WellRemoveLiquidityImbalancedTest is TestHelper {
     /// @dev not enough LP to receive `tokenAmountsOut`
     function test_removeLiquidityImbalanced_revertIf_notEnoughLP() public prank(user) {
         uint maxLpAmountIn = 10 * 1e27;
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, tokenAmountsOut[0], 0));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, tokenAmountsOut[0], 0));
         well.removeLiquidityImbalanced(maxLpAmountIn, tokenAmountsOut, user);
     }
 

--- a/test/Well.RemoveLiquidityOneToken.t.sol
+++ b/test/Well.RemoveLiquidityOneToken.t.sol
@@ -8,6 +8,8 @@ contract WellRemoveLiquidityOneTokenTest is TestHelper {
     bytes constant data = "";
     uint constant addedLiquidity = 1000 * 1e18;
 
+    error SlippageOut(uint amountOut, uint minAmountOut);
+
     event RemoveLiquidityOneToken(uint lpAmountIn, IERC20 tokenOut, uint tokenAmountOut, address recipient);
 
     function setUp() public {
@@ -57,7 +59,7 @@ contract WellRemoveLiquidityOneTokenTest is TestHelper {
     function test_removeLiquidityOneToken_revertIf_amountOutTooLow() public prank(user) {
         uint lpAmountIn = 1000 * 1e18;
         uint minTokenAmountOut = 876 * 1e18;
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, lpAmountIn, minTokenAmountOut));
         well.removeLiquidityOneToken(lpAmountIn, tokens[0], minTokenAmountOut, user);
     }
 

--- a/test/Well.RemoveLiquidityOneToken.t.sol
+++ b/test/Well.RemoveLiquidityOneToken.t.sol
@@ -2,13 +2,12 @@
 pragma solidity ^0.8.17;
 
 import {TestHelper, ConstantProduct2, IERC20, Balances} from "test/TestHelper.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 contract WellRemoveLiquidityOneTokenTest is TestHelper {
     ConstantProduct2 cp;
     bytes constant data = "";
     uint constant addedLiquidity = 1000 * 1e18;
-
-    error SlippageOut(uint amountOut, uint minAmountOut);
 
     event RemoveLiquidityOneToken(uint lpAmountIn, IERC20 tokenOut, uint tokenAmountOut, address recipient);
 
@@ -59,7 +58,7 @@ contract WellRemoveLiquidityOneTokenTest is TestHelper {
     function test_removeLiquidityOneToken_revertIf_amountOutTooLow() public prank(user) {
         uint lpAmountIn = 1000 * 1e18;
         uint minTokenAmountOut = 876 * 1e18;
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, lpAmountIn, minTokenAmountOut));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, lpAmountIn, minTokenAmountOut));
         well.removeLiquidityOneToken(lpAmountIn, tokens[0], minTokenAmountOut, user);
     }
 

--- a/test/Well.Shift.t.sol
+++ b/test/Well.Shift.t.sol
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {TestHelper, Balances, ConstantProduct2, console, IERC20} from "test/TestHelper.sol";
+import {TestHelper, Balances, ConstantProduct2, IERC20} from "test/TestHelper.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 contract WellShiftTest is TestHelper {
     ConstantProduct2 cp;
     bytes constant data = "";
-
-    error SlippageIn(uint amountIn, uint maxAmountIn);
 
     event Shift(uint[] reserves, IERC20 toToken, uint minAmountOut, address recipient);
 
@@ -164,7 +163,7 @@ contract WellShiftTest is TestHelper {
         assertEq(userBalanceBeforeShift.tokens[0], 0, "User should start with 0 of token0");
         assertEq(userBalanceBeforeShift.tokens[1], 0, "User should start with 0 of token1");
 
-        vm.expectRevert(abi.encodeWithSelector(SlippageIn.selector, amount, type(uint).max));
-        uint amtOut = well.shift(tokens[1], type(uint).max, _user);
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageIn.selector, amount, type(uint).max));
+        well.shift(tokens[1], type(uint).max, _user);
     }
 }

--- a/test/Well.Shift.t.sol
+++ b/test/Well.Shift.t.sol
@@ -7,6 +7,8 @@ contract WellShiftTest is TestHelper {
     ConstantProduct2 cp;
     bytes constant data = "";
 
+    error SlippageIn(uint amountIn, uint maxAmountIn);
+
     event Shift(uint[] reserves, IERC20 toToken, uint minAmountOut, address recipient);
 
     function setUp() public {
@@ -162,7 +164,7 @@ contract WellShiftTest is TestHelper {
         assertEq(userBalanceBeforeShift.tokens[0], 0, "User should start with 0 of token0");
         assertEq(userBalanceBeforeShift.tokens[1], 0, "User should start with 0 of token1");
 
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageIn.selector, amount, type(uint).max));
         uint amtOut = well.shift(tokens[1], type(uint).max, _user);
     }
 }

--- a/test/Well.Shift.t.sol
+++ b/test/Well.Shift.t.sol
@@ -5,10 +5,9 @@ import {TestHelper, Balances, ConstantProduct2, IERC20} from "test/TestHelper.so
 import {IWell} from "src/interfaces/IWell.sol";
 
 contract WellShiftTest is TestHelper {
-    ConstantProduct2 cp;
-    bytes constant data = "";
-
     event Shift(uint[] reserves, IERC20 toToken, uint minAmountOut, address recipient);
+    
+    ConstantProduct2 cp;
 
     function setUp() public {
         cp = new ConstantProduct2();
@@ -155,15 +154,8 @@ contract WellShiftTest is TestHelper {
         assertEq(wellBalanceBeforeShift.tokens[0], 1000e18 + amount, "Well should have received token0");
         assertEq(wellBalanceBeforeShift.tokens[1], 1000e18, "Well should have NOT have received token1");
 
-        // Get a user with a fresh address (no ERC20 tokens)
-        address _user = users.getNextUserAddress();
-        Balances memory userBalanceBeforeShift = getBalances(_user, well);
-
-        // Verify that `_user` has no tokens
-        assertEq(userBalanceBeforeShift.tokens[0], 0, "User should start with 0 of token0");
-        assertEq(userBalanceBeforeShift.tokens[1], 0, "User should start with 0 of token1");
-
-        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageIn.selector, amount, type(uint).max));
-        well.shift(tokens[1], type(uint).max, _user);
+        uint amountOut = well.getShiftOut(tokens[1]);
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountOut, type(uint).max));
+        well.shift(tokens[1], type(uint).max, user);
     }
 }

--- a/test/Well.SwapFrom.t.sol
+++ b/test/Well.SwapFrom.t.sol
@@ -7,6 +7,10 @@ import {MockFunctionBad} from "mocks/functions/MockFunctionBad.sol";
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
 
 contract WellSwapFromTest is SwapHelper {
+
+    error SlippageOut(uint amountOut, uint minAmountOut);
+    error InvalidTokens();
+
     function setUp() public {
         setupWell(2);
     }
@@ -48,7 +52,7 @@ contract WellSwapFromTest is SwapHelper {
 
     /// @dev Swaps should always revert if `fromToken` = `toToken`.
     function test_swapFrom_revertIf_sameToken() public prank(user) {
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         well.swapFrom(tokens[0], tokens[0], 100 * 1e18, 0, user);
     }
 
@@ -57,7 +61,7 @@ contract WellSwapFromTest is SwapHelper {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 501 * 1e18; // actual: 500
 
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amountIn, minAmountOut));
         well.swapFrom(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 

--- a/test/Well.SwapFrom.t.sol
+++ b/test/Well.SwapFrom.t.sol
@@ -21,10 +21,10 @@ contract WellSwapFromTest is SwapHelper {
     }
 
     function testFuzz_getSwapOut_revertIf_insufficientWellBalance(uint amountIn, uint i) public prank(user) {
-        // swap token `i` -> all other tokens
+        // Swap token `i` -> all other tokens
         vm.assume(i < tokens.length);
 
-        // find an input amount that produces an output amount higher than what the Well has.
+        // Find an input amount that produces an output amount higher than what the Well has.
         // When the Well is deployed it has zero reserves, so any nonzero value should revert.
         amountIn = bound(amountIn, 1, type(uint128).max);
 
@@ -58,8 +58,9 @@ contract WellSwapFromTest is SwapHelper {
     function test_swapFrom_revertIf_minAmountOutTooHigh() public prank(user) {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 501 * 1e18; // actual: 500
+        uint amountOut = 500 * 1e18;
 
-        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountIn, minAmountOut));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountOut, minAmountOut));
         well.swapFrom(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 

--- a/test/Well.SwapFrom.t.sol
+++ b/test/Well.SwapFrom.t.sol
@@ -5,11 +5,9 @@ import {IERC20, Balances, Call, MockToken, Well, console} from "test/TestHelper.
 import {SwapHelper, SwapAction, SwapSnapshot} from "test/SwapHelper.sol";
 import {MockFunctionBad} from "mocks/functions/MockFunctionBad.sol";
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 contract WellSwapFromTest is SwapHelper {
-
-    error SlippageOut(uint amountOut, uint minAmountOut);
-    error InvalidTokens();
 
     function setUp() public {
         setupWell(2);
@@ -52,7 +50,7 @@ contract WellSwapFromTest is SwapHelper {
 
     /// @dev Swaps should always revert if `fromToken` = `toToken`.
     function test_swapFrom_revertIf_sameToken() public prank(user) {
-        vm.expectRevert(InvalidTokens.selector);
+        vm.expectRevert(IWell.InvalidTokens.selector);
         well.swapFrom(tokens[0], tokens[0], 100 * 1e18, 0, user);
     }
 
@@ -61,7 +59,7 @@ contract WellSwapFromTest is SwapHelper {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 501 * 1e18; // actual: 500
 
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amountIn, minAmountOut));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountIn, minAmountOut));
         well.swapFrom(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 

--- a/test/Well.SwapFromFeeOnTransfer.Fee.t.sol
+++ b/test/Well.SwapFromFeeOnTransfer.Fee.t.sol
@@ -13,6 +13,9 @@ import {IWellFunction} from "src/interfaces/IWellFunction.sol";
  * a fee on transfer.
  */
 contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
+
+    error SlippageOut(uint amountOut, uint minAmountOut);
+
     function setUp() public {
         tokens = new IERC20[](2);
         tokens[0] = deployMockTokenFeeOnTransfer(0); // token[0] has fee
@@ -29,7 +32,7 @@ contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
     function test_swapFromFeeOnTransfer_revertIf_minAmountOutTooHigh_fee() public prank(user) {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 500 * 1e18;
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amountIn, minAmountOut));
         well.swapFromFeeOnTransfer(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 

--- a/test/Well.SwapFromFeeOnTransfer.Fee.t.sol
+++ b/test/Well.SwapFromFeeOnTransfer.Fee.t.sol
@@ -2,19 +2,18 @@
 pragma solidity ^0.8.17;
 
 import {
-    MockTokenFeeOnTransfer, TestHelper, IERC20, Balances, Call, MockToken, Well, console
+    MockTokenFeeOnTransfer, TestHelper, IERC20, Balances, Call, MockToken, Well
 } from "test/TestHelper.sol";
 import {SwapHelper, SwapAction, SwapSnapshot} from "test/SwapHelper.sol";
 import {MockFunctionBad} from "mocks/functions/MockFunctionBad.sol";
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 /**
  * @dev Tests {swapFromFeeOnTransfer} when tokens involved in the swap incur
  * a fee on transfer.
  */
 contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
-
-    error SlippageOut(uint amountOut, uint minAmountOut);
 
     function setUp() public {
         tokens = new IERC20[](2);
@@ -32,7 +31,7 @@ contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
     function test_swapFromFeeOnTransfer_revertIf_minAmountOutTooHigh_fee() public prank(user) {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 500 * 1e18;
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amountIn, minAmountOut));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountIn, minAmountOut));
         well.swapFromFeeOnTransfer(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 

--- a/test/Well.SwapFromFeeOnTransfer.Fee.t.sol
+++ b/test/Well.SwapFromFeeOnTransfer.Fee.t.sol
@@ -31,7 +31,9 @@ contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
     function test_swapFromFeeOnTransfer_revertIf_minAmountOutTooHigh_fee() public prank(user) {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 500 * 1e18;
-        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountIn, minAmountOut));
+        uint amountOut = well.getSwapOut(tokens[0], tokens[1], amountIn - _getFee(amountIn));
+        
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountOut, minAmountOut));
         well.swapFromFeeOnTransfer(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 
@@ -54,8 +56,7 @@ contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
         act.i = 0;
         act.j = 1;
         act.userSpends = amountIn;
-        uint _fee = act.userSpends * MockTokenFeeOnTransfer(address(tokens[0])).fee() / 1e18;
-        act.wellReceives = amountIn - _fee;
+        act.wellReceives = amountIn - _getFee(act.userSpends);
         act.wellSends = well.getSwapOut(tokens[act.i], tokens[act.j], act.wellReceives);
         act.userReceives = act.wellSends;
 
@@ -93,8 +94,7 @@ contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
         act.userSpends = amountIn;
         act.wellReceives = amountIn;
         act.wellSends = well.getSwapOut(tokens[act.i], tokens[act.j], amountIn);
-        uint _fee = act.wellSends * MockTokenFeeOnTransfer(address(tokens[0])).fee() / 1e18;
-        act.userReceives = act.wellSends - _fee;
+        act.userReceives = act.wellSends - _getFee(act.wellSends);
 
         (bef, act) = beforeSwapFrom(act);
 
@@ -103,5 +103,9 @@ contract WellSwapFromFeeOnTransferFeeTest is SwapHelper {
 
         assertEq(amountOut, act.wellSends, "amountOut different than calculated");
         afterSwapFrom(bef, act);
+    }
+
+    function _getFee(uint amount) internal view returns (uint) {
+        return amount * MockTokenFeeOnTransfer(address(tokens[0])).fee() / 1e18;
     }
 }

--- a/test/Well.SwapFromFeeOnTransfer.NoFee.t.sol
+++ b/test/Well.SwapFromFeeOnTransfer.NoFee.t.sol
@@ -20,8 +20,9 @@ contract WellSwapFromFeeOnTransferNoFeeTest is SwapHelper {
     function test_swapFromFeeOnTransfer_noFee_revertIf_minAmountOutTooHigh() public prank(user) {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 501 * 1e18; // actual: 500
+        uint amountOut = 500 * 1e18;
 
-        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountIn, minAmountOut));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountOut, minAmountOut));
         well.swapFromFeeOnTransfer(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 

--- a/test/Well.SwapFromFeeOnTransfer.NoFee.t.sol
+++ b/test/Well.SwapFromFeeOnTransfer.NoFee.t.sol
@@ -1,20 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {TestHelper, IERC20, Balances, Call, MockToken, Well, console} from "test/TestHelper.sol";
+import {TestHelper, IERC20, Balances, Call, MockToken, Well} from "test/TestHelper.sol";
 import {SwapHelper, SwapAction, SwapSnapshot} from "test/SwapHelper.sol";
 import {MockFunctionBad} from "mocks/functions/MockFunctionBad.sol";
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 /**
  * @dev Tests {swapFromFeeOnTransfer} when tokens involved in the swap DO NOT
  * incur a fee on transfer.
  */
 contract WellSwapFromFeeOnTransferNoFeeTest is SwapHelper {
-
-    error SlippageOut(uint amountOut, uint minAmountOut);
-    error InvalidTokens();
-
     function setUp() public {
         setupWell(2);
     }
@@ -24,7 +21,7 @@ contract WellSwapFromFeeOnTransferNoFeeTest is SwapHelper {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 501 * 1e18; // actual: 500
 
-        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amountIn, minAmountOut));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageOut.selector, amountIn, minAmountOut));
         well.swapFromFeeOnTransfer(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 
@@ -32,7 +29,7 @@ contract WellSwapFromFeeOnTransferNoFeeTest is SwapHelper {
     function testFuzz_swapFromFeeOnTransfer_noFee_revertIf_sameToken(uint128 amountIn) public prank(user) {
         MockToken(address(tokens[0])).mint(user, amountIn);
 
-        vm.expectRevert(InvalidTokens.selector);
+        vm.expectRevert(IWell.InvalidTokens.selector);
         well.swapFromFeeOnTransfer(tokens[0], tokens[0], amountIn, 0, user);
     }
 

--- a/test/Well.SwapFromFeeOnTransfer.NoFee.t.sol
+++ b/test/Well.SwapFromFeeOnTransfer.NoFee.t.sol
@@ -11,6 +11,10 @@ import {IWellFunction} from "src/interfaces/IWellFunction.sol";
  * incur a fee on transfer.
  */
 contract WellSwapFromFeeOnTransferNoFeeTest is SwapHelper {
+
+    error SlippageOut(uint amountOut, uint minAmountOut);
+    error InvalidTokens();
+
     function setUp() public {
         setupWell(2);
     }
@@ -20,7 +24,7 @@ contract WellSwapFromFeeOnTransferNoFeeTest is SwapHelper {
         uint amountIn = 1000 * 1e18;
         uint minAmountOut = 501 * 1e18; // actual: 500
 
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageOut.selector, amountIn, minAmountOut));
         well.swapFromFeeOnTransfer(tokens[0], tokens[1], amountIn, minAmountOut, user);
     }
 
@@ -28,7 +32,7 @@ contract WellSwapFromFeeOnTransferNoFeeTest is SwapHelper {
     function testFuzz_swapFromFeeOnTransfer_noFee_revertIf_sameToken(uint128 amountIn) public prank(user) {
         MockToken(address(tokens[0])).mint(user, amountIn);
 
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         well.swapFromFeeOnTransfer(tokens[0], tokens[0], amountIn, 0, user);
     }
 

--- a/test/Well.SwapTo.t.sol
+++ b/test/Well.SwapTo.t.sol
@@ -46,7 +46,9 @@ contract WellSwapToTest is SwapHelper {
     function test_swapTo_revertIf_maxAmountInTooLow() public prank(user) {
         uint amountOut = 500 * 1e18;
         uint maxAmountIn = 999 * 1e18; // actual: 1000
-        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageIn.selector, amountOut, maxAmountIn));
+        uint amountIn = 1000 * 1e18;
+
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageIn.selector, amountIn, maxAmountIn));
         well.swapTo(tokens[0], tokens[1], maxAmountIn, amountOut, user);
     }
 

--- a/test/Well.SwapTo.t.sol
+++ b/test/Well.SwapTo.t.sol
@@ -7,6 +7,10 @@ import {MockFunctionBad} from "mocks/functions/MockFunctionBad.sol";
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
 
 contract WellSwapToTest is SwapHelper {
+
+    error SlippageIn(uint amountIn, uint maxAmountIn);
+    error InvalidTokens();
+
     function setUp() public {
         setupWell(2);
     }
@@ -36,7 +40,7 @@ contract WellSwapToTest is SwapHelper {
 
     /// @dev Swaps should always revert if `fromToken` = `toToken`.
     function test_swapTo_revertIf_sameToken() public prank(user) {
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         well.swapTo(tokens[0], tokens[0], 100 * 1e18, 0, user);
     }
 
@@ -44,7 +48,7 @@ contract WellSwapToTest is SwapHelper {
     function test_swapTo_revertIf_maxAmountInTooLow() public prank(user) {
         uint amountOut = 500 * 1e18;
         uint maxAmountIn = 999 * 1e18; // actual: 1000
-        vm.expectRevert("Well: slippage");
+        vm.expectRevert(abi.encodeWithSelector(SlippageIn.selector, amountOut, maxAmountIn));
         well.swapTo(tokens[0], tokens[1], maxAmountIn, amountOut, user);
     }
 

--- a/test/Well.SwapTo.t.sol
+++ b/test/Well.SwapTo.t.sol
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {IERC20, Balances, Call, MockToken, Well, console} from "test/TestHelper.sol";
+import {IERC20, Balances, Call, MockToken, Well} from "test/TestHelper.sol";
 import {SwapHelper, SwapAction, SwapSnapshot} from "test/SwapHelper.sol";
 import {MockFunctionBad} from "mocks/functions/MockFunctionBad.sol";
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+import {IWell} from "src/interfaces/IWell.sol";
 
 contract WellSwapToTest is SwapHelper {
-
-    error SlippageIn(uint amountIn, uint maxAmountIn);
-    error InvalidTokens();
 
     function setUp() public {
         setupWell(2);
@@ -40,7 +38,7 @@ contract WellSwapToTest is SwapHelper {
 
     /// @dev Swaps should always revert if `fromToken` = `toToken`.
     function test_swapTo_revertIf_sameToken() public prank(user) {
-        vm.expectRevert(InvalidTokens.selector);
+        vm.expectRevert(IWell.InvalidTokens.selector);
         well.swapTo(tokens[0], tokens[0], 100 * 1e18, 0, user);
     }
 
@@ -48,7 +46,7 @@ contract WellSwapToTest is SwapHelper {
     function test_swapTo_revertIf_maxAmountInTooLow() public prank(user) {
         uint amountOut = 500 * 1e18;
         uint maxAmountIn = 999 * 1e18; // actual: 1000
-        vm.expectRevert(abi.encodeWithSelector(SlippageIn.selector, amountOut, maxAmountIn));
+        vm.expectRevert(abi.encodeWithSelector(IWell.SlippageIn.selector, amountOut, maxAmountIn));
         well.swapTo(tokens[0], tokens[1], maxAmountIn, amountOut, user);
     }
 
@@ -66,8 +64,6 @@ contract WellSwapToTest is SwapHelper {
         uint[] memory calcBalances = new uint[](wellBalancesBefore.tokens.length);
         calcBalances[0] = wellBalancesBefore.tokens[0];
         calcBalances[1] = wellBalancesBefore.tokens[1] - amountOut;
-
-        console.log(calcBalances[1], wellBalancesBefore.tokens[1]);
 
         uint calcAmountIn = IWellFunction(wellFunction.target).calcReserve(
             calcBalances,

--- a/test/Well.Tokens.sol
+++ b/test/Well.Tokens.sol
@@ -45,7 +45,7 @@ contract WellInternalTest is Well, Test {
         for (uint i = 0; i < n; ++i) {
             for (uint j = 0; j < n; ++j) {
                 if (i == j) {
-                    vm.expectRevert("Well: Invalid tokens");
+                    vm.expectRevert(InvalidTokens.selector);
                 }
                 (uint i_, uint j_) = _getIJ(_tokens, _tokens[i], _tokens[j]);
                 if (i != j) {
@@ -57,20 +57,20 @@ contract WellInternalTest is Well, Test {
     }
 
     function test_getIJ_revertIfIdentical() public {
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         _getIJ(_tokens, token0, token0);
     }
 
     function test_getIJ_revertIfOneMissing() public {
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         _getIJ(_tokens, tokenMissing1, token0); // i is missing
 
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         _getIJ(_tokens, token0, tokenMissing1); // j is missing
     }
 
     function test_getIJ_revertIfBothMissing() public {
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         _getIJ(_tokens, tokenMissing1, tokenMissing2);
     }
 
@@ -83,7 +83,7 @@ contract WellInternalTest is Well, Test {
     }
 
     function test_getJ_revertIfMissing() public {
-        vm.expectRevert("Well: Invalid tokens");
+        vm.expectRevert(InvalidTokens.selector);
         _getJ(_tokens, tokenMissing1);
     }
 }


### PR DESCRIPTION
@pynchmeister:
1. Implement these errors in Well.sol (see https://blog.soliditylang.org/2021/04/21/custom-errors/)
2. Update all tests to use the custom errors (see https://book.getfoundry.sh/cheatcodes/expect-revert#examples)
3. Add Natspec docs to each error