### PR TITLE
ci: upgrade to actions v4 and official foundry action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -22,7 +24,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Basin
 
+![Tests](https://github.com/AdekunleBamz/Basin/actions/workflows/tests.yml/badge.svg)
+
 Code Version: `1.0.0` <br>
 Whitepaper Version: `1.0.0`
 


### PR DESCRIPTION
This PR modernizes the CI infrastructure:

- **CI Upgrade:** Updated to `actions/checkout@v4` with explicit submodule support for better dependency handling.
- **Foundry Action:** Migrated from the deprecated `onbjerg/foundry-toolchain@v1` to the official `foundry-rs/foundry-toolchain@v1` action, ensuring continued support and updates.
- **Documentation:** Added a visible Build Status badge to the README.